### PR TITLE
Chunked encoding

### DIFF
--- a/Source Packages/io/rerum/crud/Constant.java
+++ b/Source Packages/io/rerum/crud/Constant.java
@@ -10,11 +10,11 @@ package io.rerum.crud;
  * @author bhaberbe
  */
 public class Constant {
-    public static String RERUM_REGISTRATION_URL = "http://store.rerum.io/v1/";
-    public static String RERUM_API_ADDR = "http://store.rerum.io/v1/api";
-    //public static String RERUM_ID_PATTERN = "//store.rerum.io/v1/id";
-    public static String RERUM_ACCESS_TOKEN_URL = "http://store.rerum.io/v1/api/accessToken.action";
-    public static String RERUM_REFRESH_TOKEN_URL = "http://store.rerum.io/v1/api/refreshToken.action";
+    public static String RERUM_REGISTRATION_URL = "http://devstore.rerum.io/v1/";
+    public static String RERUM_API_ADDR = "http://devstore.rerum.io/v1/api";
+    //public static String RERUM_ID_PATTERN = "//devstore.rerum.io/v1/id";
+    public static String RERUM_ACCESS_TOKEN_URL = "http://devstore.rerum.io/v1/api/accessToken.action";
+    public static String RERUM_REFRESH_TOKEN_URL = "http://devstore.rerum.io/v1/api/refreshToken.action";
     
     //https://stackoverflow.com/questions/2395737/java-relative-path-of-a-file-in-a-java-web-application
     public static String PROPERTIES_FILE_NAME = "tiny.properties";

--- a/Source Packages/io/rerum/crud/Constant.java
+++ b/Source Packages/io/rerum/crud/Constant.java
@@ -10,11 +10,11 @@ package io.rerum.crud;
  * @author bhaberbe
  */
 public class Constant {
-    public static String RERUM_REGISTRATION_URL = "http://devstore.rerum.io/v1/";
-    public static String RERUM_API_ADDR = "http://devstore.rerum.io/v1/api";
-    //public static String RERUM_ID_PATTERN = "//devstore.rerum.io/v1/id";
-    public static String RERUM_ACCESS_TOKEN_URL = "http://devstore.rerum.io/v1/api/accessToken.action";
-    public static String RERUM_REFRESH_TOKEN_URL = "http://devstore.rerum.io/v1/api/refreshToken.action";
+    public static String RERUM_REGISTRATION_URL = "http://store.rerum.io/v1/";
+    public static String RERUM_API_ADDR = "http://store.rerum.io/v1/api";
+    //public static String RERUM_ID_PATTERN = "//store.rerum.io/v1/id";
+    public static String RERUM_ACCESS_TOKEN_URL = "http://store.rerum.io/v1/api/accessToken.action";
+    public static String RERUM_REFRESH_TOKEN_URL = "http://store.rerum.io/v1/api/refreshToken.action";
     
     //https://stackoverflow.com/questions/2395737/java-relative-path-of-a-file-in-a-java-web-application
     public static String PROPERTIES_FILE_NAME = "tiny.properties";

--- a/Source Packages/io/rerum/crud/TinyDelete.java
+++ b/Source Packages/io/rerum/crud/TinyDelete.java
@@ -93,7 +93,9 @@ public class TinyDelete extends HttpServlet {
                 for (String value : entries.getValue()) {
                     values += value + ",";
                 }
-                response.setHeader(entries.getKey(), values);
+                if(null != entries.getKey() && !entries.getKey().equals("Transfer-Encoding")){
+                    response.setHeader(entries.getKey(), values);
+                }
             }
         }
         catch(IOException ex){

--- a/Source Packages/io/rerum/crud/TinyOverwrite.java
+++ b/Source Packages/io/rerum/crud/TinyOverwrite.java
@@ -19,6 +19,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import net.sf.json.JSONObject;
 import io.rerum.tokens.TinyTokenManager;
+import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -97,6 +99,15 @@ public class TinyOverwrite extends HttpServlet {
                     sb.append(line);
                 }
                 reader.close();
+                for (Map.Entry<String, List<String>> entries : connection.getHeaderFields().entrySet()) {
+                    String values = "";
+                    for (String value : entries.getValue()) {
+                        values += value + ",";
+                    }
+                    if(null != entries.getKey() && !entries.getKey().equals("Transfer-Encoding")){
+                        response.setHeader(entries.getKey(), values);
+                    }
+                }
             }
             catch(IOException ex){
                 //Need to get the response RERUM sent back.

--- a/Source Packages/io/rerum/crud/TinyQuery.java
+++ b/Source Packages/io/rerum/crud/TinyQuery.java
@@ -108,7 +108,9 @@ public class TinyQuery extends HttpServlet {
                     for (String value : entries.getValue()) {
                         values += value + ",";
                     }
-                    response.setHeader(entries.getKey(), values);
+                    if(null != entries.getKey() && !entries.getKey().equals("Transfer-Encoding")){
+                        response.setHeader(entries.getKey(), values);
+                    }
                 }
             }
             catch(IOException ex){

--- a/Source Packages/io/rerum/crud/TinySave.java
+++ b/Source Packages/io/rerum/crud/TinySave.java
@@ -74,7 +74,6 @@ public class TinySave extends HttpServlet {
                 System.out.println("Tiny thing detected an expired token, auto getting and setting a new one...");
                 pubTok = manager.generateNewAccessToken();
             }
-            System.out.println("Bearer token is set for Tiny Save, connecting to RERUM for create...");
             //Point to rerum server v1
             URL postUrl = new URL(Constant.RERUM_API_ADDR + "/create.action");
             HttpURLConnection connection = (HttpURLConnection) postUrl.openConnection();
@@ -121,7 +120,6 @@ public class TinySave extends HttpServlet {
                 error.close();
             }
             connection.disconnect();
-            System.out.println("RERUM create responded, out that to user!");
             //Hand back rerumserver response as this API's response.
             if(manager.getAPISetting().equals("true")){
                 response.addHeader("Access-Control-Allow-Origin", "*"); //To use this as an API, it must contain CORS headers

--- a/Source Packages/io/rerum/crud/TinySave.java
+++ b/Source Packages/io/rerum/crud/TinySave.java
@@ -106,7 +106,9 @@ public class TinySave extends HttpServlet {
                     for (String value : entries.getValue()) {
                         values += value + ",";
                     }
-                    response.setHeader(entries.getKey(), values);
+                    if(null != entries.getKey() && !entries.getKey().equals("Transfer-Encoding")){
+                        response.setHeader(entries.getKey(), values);
+                    }
                 }
             }
             catch(IOException ex){

--- a/Source Packages/io/rerum/crud/TinyUpdate.java
+++ b/Source Packages/io/rerum/crud/TinyUpdate.java
@@ -107,7 +107,9 @@ public class TinyUpdate extends HttpServlet {
                     for (String value : entries.getValue()) {
                         values += value + ",";
                     }
-                    response.setHeader(entries.getKey(), values);
+                    if(null != entries.getKey() && !entries.getKey().equals("Transfer-Encoding")){
+                        response.setHeader(entries.getKey(), values);
+                    }
                 }
             } catch (IOException ex) {
                 //Need to get the response RERUM sent back.

--- a/Source Packages/io/rerum/tokens/TinyTokenManager.java
+++ b/Source Packages/io/rerum/tokens/TinyTokenManager.java
@@ -100,8 +100,8 @@ public class TinyTokenManager{
             return nowTime >= expires;
         } 
         catch (Exception exception){
-            System.out.println(token);
             System.out.println("Problem with token, no way to check expiry");
+            System.out.println(token);
             System.out.println(exception);
             return true;
         }


### PR DESCRIPTION
We experienced issues with TinyThings trying to make a request through TinyQuery with body 

`{__rerum.generatedBy : http://store.rerum.io/v1/id/5b75bdc2d5de7603cc408110}`

This request threw the error `ERR_INVALID_CHUNKED_ENCODING`.

The most peculiar situation was that it appeared to be tied directly to this request.  Attempts to reproduce this error through queries in the development environment were unsuccessful.  Attempts to produce it against other queries in the production environment were unsuccessful.

It was obvious some investigation across the stack was required to gain further insight.  After much digging for clues, I discovered this problem most often occurs in set ups like

![image](https://user-images.githubusercontent.com/3287006/70749836-c5896280-1cf2-11ea-9819-490fc7f71718.png)

In this set up, some client initiates a request to a back-end which in turn sends a request to an origin server on which the processing of that request occurs.  Once the origin server does the processing, it replies to the proxy server, which in turn may do some processing then responds to the client which reacts to the response from the proxy.  

For our situation, `client` is Chrome running on my PC, `proxy` is TinyThings back-end running on `prd-01`, and `origin` is the rerum_server back-end on `prd-02`.  

I decided to look into all the headers on the request/response objects happening between each of these pieces.  Below is a header reading from TinyThing’s /query endpoint on `prd-01` when running the query giving the error.
```html
Forward header Transfer-Encoding : chunked,
Forward header Keep-Alive : timeout=5, max=100,
Forward header null : HTTP/1.1 200 OK,
Forward header Server : Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips mod_jk/1.2.42,
Forward header Access-Control-Allow-Origin : *,
Forward header Access-Control-Allow-Methods : GET,OPTIONS,HEAD,PUT,PATCH,DELETE,POST,
Forward header Connection : Keep-Alive,
Forward header Access-Control-Allow-Headers : Content-Type,
Forward header Date : Thu, 12 Dec 2019 19:27:40 GMT,
Forward header Content-Type : application/json;charset=UTF-8
Response To Client
{The return I was looking for}
```
The following is from a different request that did not throw the error
```html
Forward header Keep-Alive : timeout=5, max=100,
Forward header null : HTTP/1.1 200 OK,
Forward header Server : Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips mod_jk/1.2.42,
Forward header Access-Control-Allow-Origin : *,
Forward header Access-Control-Allow-Methods : GET,OPTIONS,HEAD,PUT,PATCH,DELETE,POST,
Forward header Connection : Keep-Alive,
Forward header Access-Control-Allow-Headers : Content-Type,
Forward header Date : Thu, 12 Dec 2019 19:27:40 GMT,
Forward header Content-Type : application/json;charset=UTF-8
Response To Client
{The return I was looking for, except this one made it to the client}
```
This meant `prd-01` was receiving the data from `prd-02` correctly, since I could see `{the return I was looking for}` when building the response for the `client`.  However, on the `client`, there was never a response body.  Why wasn’t that response reaching the `client`?

There is only one difference between these header readings.
 `Forward header Transfer-Encoding : chunked`

What I learned about that header solved this mystery.  A server can (seemingly arbitrarily) decide that the size of a response is unknown.  In these cases, it does not know whether the body it has is the complete object or whether there is more to come.  It will put `Transfer-Encoding : chunked` in the header, which tells the client that the body is incomplete and to expect more data to be transferred.  It will know it has the entire body once the last chunk is sent and closes the connection.

How did that header make it from the origin server to the client?  As best practice, the proxy server grabs all responses from the origin server and supplants them into the proxy response for the client.  The problem is that `prd-01` didn’t treat this as something that needed chunked encoding and prepared a singular response with the object in its entirety, and so the pipeline shattered.  The client would not be able to receive the body so long as the `Transfer-Encoding : chunked` header was included on responses from the proxy telling the client there was more to come.  

This is peculiar, since it seems we have almost no control over when `prd-02` or `prd-01` will decide when the `Transfer-Encoding : chunked` header should be applied automatically.  The true fix to the problem is to figure out why `prd-02` thinks it needs to automatically add the header in this case.  That fix is best left to a server admin.  

The fix we will choose to implement lies in the best practice of forwarding the headers.  If the proxy ignores `Transfer-Encoding : chunked` and does not supplant that header on the response to the client, then the client will not treat the response as chunked and will accept the body.  At the present, we expect responses from `prd-02` to contain all the data in a singular response, so this will suffice.
In theory, scaling up would require us to get a handle on this issue on `prd-02`, but we should not come across that for a long time.  Let this be a forewarning of the complications scaling up can cause.  

This version has been deployed in dev and prod.  
