### PR TITLE
Overwrite Pre-flight afternoon delight

### DIFF
--- a/Source Packages/io/rerum/crud/TinyDelete.java
+++ b/Source Packages/io/rerum/crud/TinyDelete.java
@@ -175,7 +175,7 @@ public class TinyDelete extends HttpServlet {
             response.setStatus(200);
             
         } catch (Exception ex) {
-            Logger.getLogger(TinyQuery.class.getName()).log(Level.SEVERE, null, ex);
+            Logger.getLogger(TinyDelete.class.getName()).log(Level.SEVERE, null, ex);
         }
     }
 

--- a/Source Packages/io/rerum/crud/TinyOverwrite.java
+++ b/Source Packages/io/rerum/crud/TinyOverwrite.java
@@ -144,6 +144,35 @@ public class TinyOverwrite extends HttpServlet {
             Logger.getLogger(TinyOverwrite.class.getName()).log(Level.SEVERE, null, ex);
         }
     }
+    
+    /**
+     * Handles the HTTP <code>OPTIONS</code> preflight method.
+     * This should be a configurable option.  Turning this on means you
+     * intend for this version of Tiny Things to work like an open API.  
+     *
+     * @param request servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    protected void doOptions(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        try {
+            TinyTokenManager manager = new TinyTokenManager();
+            String openAPI = manager.getAPISetting();
+            if(openAPI.equals("true")){
+                //These headers must be present to pass browser preflight for CORS
+                response.addHeader("Access-Control-Allow-Origin", "*");
+                response.addHeader("Access-Control-Allow-Headers", "*");
+                response.addHeader("Access-Control-Allow-Methods", "*");
+            }
+            response.setStatus(200);
+            
+        } catch (Exception ex) {
+            Logger.getLogger(TinyOverwrite.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
 
     /**
      * Returns a short description of the servlet.

--- a/Source Packages/io/rerum/crud/TinySave.java
+++ b/Source Packages/io/rerum/crud/TinySave.java
@@ -189,7 +189,7 @@ public class TinySave extends HttpServlet {
             response.setStatus(200);
             
         } catch (Exception ex) {
-            Logger.getLogger(TinyQuery.class.getName()).log(Level.SEVERE, null, ex);
+            Logger.getLogger(TinySave.class.getName()).log(Level.SEVERE, null, ex);
         }
     }
 

--- a/Source Packages/io/rerum/crud/TinyUpdate.java
+++ b/Source Packages/io/rerum/crud/TinyUpdate.java
@@ -190,7 +190,7 @@ public class TinyUpdate extends HttpServlet {
             response.setStatus(200);
             
         } catch (Exception ex) {
-            Logger.getLogger(TinyQuery.class.getName()).log(Level.SEVERE, null, ex);
+            Logger.getLogger(TinyUpdate.class.getName()).log(Level.SEVERE, null, ex);
         }
     }
 


### PR DESCRIPTION
This is a blocking issue for https://github.com/CenterForDigitalHumanities/deer/tree/process_simple_record_fix.  

The overwrite endpoint did not have the preflight request handler.  It is now included.  

I also noticed that the `Logger` referenced the `TinyQuery` class in the preflight handlers (no doubt a C & P side effect).  I updated the references to the current class, where applicable.  

Once accepted, this will need to be deployed on dev and prod ASAP.  